### PR TITLE
DGC1 README - minor adjustments to instructions

### DIFF
--- a/docs/design_dgc1/README.md
+++ b/docs/design_dgc1/README.md
@@ -69,12 +69,13 @@ To run the Bootloader .elf program, follow the steps below or refer to the *MIV_
 
     1. Open SoftConsole (v2021.1 or above)
     2. From Run > Debug Configurations, double click GDB OpenOCD Debugging
-    3. In the Main window, select C/C++ Applications using the Browse button, then navigate to your Libero's project directory ./MIV_DGC1_BD and select the Bootloader .elf file
-    4. Select the Debugger tab to set up OpenOCD and GDB
-        a. To set up OpenOCD, check the Start OpenOCD locally check box and browse to the OpenOCD path <SoftConsole-install-directory>\openocd\bin\openocd.exe
+    3. In the Main window, select C/C++ Applications using the Browse button, then navigate to your Libero's project directory ./MIV_RV32_DGC1_BD and select the Bootloader .elf file
+    4. Select "Disable auto build" option
+    5. Select the Debugger tab to set up OpenOCD and GDB
+        a. To set up OpenOCD, check the Start OpenOCD locally check box and browse to manually set the OpenOCD path <SoftConsole-install-directory>\openocd\bin\openocd.exe
         b. To set up GDB, browse to the GDB path <SoftConsole-install-directory>\riscv-unknownelf-gcc\bin\riscv64-unknown-elf-gdb.exe.
-    5. Click Apply
-    6. Click Debug to launch the debug session. 
+    6. Click Apply
+    7. Click Debug to launch the debug session. 
 
 ## <a name="Design Guide Configuration - DGC1: SPI Write & Boot"></a> Design Guide Configuration - DGC1: SPI Write & Boot
 


### PR DESCRIPTION
Adjusted the instructions for running Bootloader .elf within the ./docs/design_dgc1/README.md file.

Signed-off: <seb.slowikowski@microchip.com>